### PR TITLE
Fix typo in ccthread usage

### DIFF
--- a/src/bin/ccthread.rs
+++ b/src/bin/ccthread.rs
@@ -29,7 +29,7 @@ fn main() {
     let mut args = std::env::args().skip(1);
     let n = args
         .next()
-        .expect("Usage: ccasync count [concurrency_limit]")
+        .expect("Usage: ccthread count [concurrency_limit]")
         .parse()
         .expect("Couldn't parse count as integer");
     let m = args


### PR DESCRIPTION
I specifically handled the copy-paste issue...and then copy-pasted again after
fixing a bug, and forgot to change it that time.
